### PR TITLE
Adicionado get para o webView interno que formata o markdown

### DIFF
--- a/library/src/main/java/br/tiagohm/markdownview/MarkdownView.java
+++ b/library/src/main/java/br/tiagohm/markdownview/MarkdownView.java
@@ -319,6 +319,13 @@ public class MarkdownView extends FrameLayout
     new LoadMarkdownUrlTask().execute(url);
   }
 
+    /**
+     * Returns the internal @WebView that holds the markdown text
+     */
+    public WebView getWebView() {
+        return mWebView;
+    }
+
   public interface OnElementListener
   {
     void onButtonTap(String id);

--- a/library/src/main/java/br/tiagohm/markdownview/MarkdownView.java
+++ b/library/src/main/java/br/tiagohm/markdownview/MarkdownView.java
@@ -319,6 +319,13 @@ public class MarkdownView extends FrameLayout
     new LoadMarkdownUrlTask().execute(url);
   }
 
+    /**
+     * Returns the internal {@link WebView} that holds the markdown text
+     */
+    public WebView getWebView() {
+        return mWebView;
+    }
+
   public interface OnElementListener
   {
     void onButtonTap(String id);


### PR DESCRIPTION
Adicionado um método `get` para o `WebView `interno que formata o markdown, para dar mais possibilidades no desenvolvimento como, por exemplo, o uso de `WebViewClient`s.